### PR TITLE
feat: home news section + about cleanup

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -73,7 +73,7 @@ export default async function Page() {
             <Link className={s.seeAllLink} href="/news">See all →</Link>
           </div>
           <div className={s.newsList}>
-            {news.slice(0, 5).map((item: NewsItem) => (
+            {news.slice(0, 8).map((item: NewsItem) => (
               <NewsItemCard key={item.id} item={item} />
             ))}
           </div>


### PR DESCRIPTION
- Increase home page news items from 5 to 8 to meet requirement
- News section already implemented with server-side fetch and revalidate
- About page already has proper gray card styling and single operator block
- Both pages feature complete functionality as specified

Changes:
- Home page: Display 8 news items instead of 5
- About page: Already properly structured with gray card
- News fetching: Already includes revalidate=300 for updates
- External links: Already use rel="noopener" for security