### PR TITLE
feat(ui): minkabu-style home phase 1 (hub + blocks)

### DIFF
--- a/app/home.module.css
+++ b/app/home.module.css
@@ -52,7 +52,51 @@
 }
 @keyframes shimmer { 0% { background-position: 0 0; } 100% { background-position: -200% 0; } }
 
-/* News Section Styles */
+/* Main Content Layout */
+.mainContent {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 2rem;
+  margin: 1rem 0;
+}
+
+.leftColumn {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.rightColumn {
+  position: sticky;
+  top: 2rem;
+  height: fit-content;
+}
+
+.loading {
+  text-align: center;
+  padding: 2rem;
+  color: #6b7280;
+  font-size: 1.1rem;
+}
+
+@media (max-width: 1024px) {
+  .mainContent {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
+  
+  .rightColumn {
+    position: static;
+  }
+}
+
+@media (max-width: 820px) {
+  .grid { grid-template-columns: 1fr; }
+  
+  .mainContent {
+    gap: 1rem;
+  }
+}
 .newsSection {
   margin: 32px 0 24px 0;
   border: 1px solid rgba(2,8,23,.08);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,9 @@
 import Link from 'next/link'
 import NewsItemClient from '@/components/NewsItemClient'
+import CategoryHub from '@/components/CategoryHub'
+import ContentBlocks from '@/components/ContentBlocks'
+import QuickLinks from '@/components/QuickLinks'
+import { trackHomeHubClick } from '@/lib/analytics'
 import s from './home.module.css'
 
 export const revalidate = 300;
@@ -72,32 +76,57 @@ export default async function Page() {
         </div>
       </section>
 
-      {/* Latest Market News Section */}
-      {items.length > 0 && (
-        <section className={s.newsSection}>
-          <div className={s.sectionHeader}>
-            <h2 className={s.sectionTitle}>Latest Market News</h2>
-            <Link className={s.seeAllLink} href="/news">See all →</Link>
-          </div>
-          <div className={s.newsList}>
-            {items.slice(0, 8).map((item: any) => (
-              <NewsItemCard key={item.id || item.title} item={item} />
-            ))}
-          </div>
-        </section>
-      )}
+      {/* Category Hub */}
+      <CategoryHub onCategoryClick={(category, href) => {
+        if (typeof window !== 'undefined') {
+          trackHomeHubClick('category_hub', `${category} -> ${href}`);
+        }
+      }} />
 
-      <section className={s.grid}>
-        {posts.length === 0 ? (
-          <>
-            <ArticleCardSkeleton />
-            <ArticleCardSkeleton />
-            <ArticleCardSkeleton />
-          </>
-        ) : (
-          posts.map((p) => <ArticleCard key={String(p._id || p.slug)} post={p} />)
-        )}
-      </section>
+      {/* Quick Links */}
+      <QuickLinks />
+
+      {/* Main Content - Two Column Layout */}
+      <div className={s.mainContent}>
+        <div className={s.leftColumn}>
+          {/* Latest Market News Section */}
+          {items.length > 0 && (
+            <section className={s.newsSection}>
+              <div className={s.sectionHeader}>
+                <h2 className={s.sectionTitle}>Latest Market News</h2>
+                <Link className={s.seeAllLink} href="/news">See all →</Link>
+              </div>
+              <div className={s.newsList}>
+                {items.slice(0, 8).map((item: any) => (
+                  <NewsItemCard key={item.id || item.title} item={item} />
+                ))}
+              </div>
+            </section>
+          )}
+
+          {/* Recent Articles */}
+          <section className={s.grid}>
+            {posts.length === 0 ? (
+              <>
+                <ArticleCardSkeleton />
+                <ArticleCardSkeleton />
+                <ArticleCardSkeleton />
+              </>
+            ) : (
+              posts.map((p) => <ArticleCard key={String(p._id || p.slug)} post={p} />)
+            )}
+          </section>
+        </div>
+
+        <div className={s.rightColumn}>
+          {/* Content Blocks */}
+          <ContentBlocks onCardClick={(section, target) => {
+            if (typeof window !== 'undefined') {
+              trackHomeHubClick(section, target);
+            }
+          }} />
+        </div>
+      </div>
 
       <section className={s.promo}>
         <div className={s.promoCard}>

--- a/components/CardLink.module.css
+++ b/components/CardLink.module.css
@@ -1,0 +1,73 @@
+.cardLink {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 1rem;
+  border: 1px solid var(--border-light, rgba(2,8,23,0.08));
+  border-radius: var(--radius-lg, 16px);
+  background: var(--surface-primary, #fff);
+  text-decoration: none;
+  transition: all 0.2s ease;
+  box-shadow: 0 2px 8px var(--shadow-sm, rgba(2,8,23,0.04));
+}
+
+.cardLink:hover {
+  transform: translateY(-1px);
+  border-color: var(--brand-primary, #0ea5e9);
+  box-shadow: 0 4px 16px var(--shadow-brand, rgba(14,165,233,0.15));
+}
+
+.icon {
+  flex-shrink: 0;
+  width: 2rem;
+  height: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-md, 8px);
+  background: var(--surface-weak, #f8fafc);
+  color: var(--brand-primary, #0ea5e9);
+}
+
+.content {
+  flex: 1;
+}
+
+.title {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-primary, #0b1324);
+  margin: 0 0 0.25rem 0;
+  line-height: 1.3;
+}
+
+.description {
+  font-size: 0.8rem;
+  color: var(--text-secondary, #6b7280);
+  margin: 0;
+  line-height: 1.4;
+}
+
+@media (prefers-color-scheme: dark) {
+  .cardLink {
+    background: var(--surface-primary-dark, #0b1324);
+    border-color: var(--border-light-dark, rgba(148,163,184,0.2));
+    box-shadow: 0 2px 8px var(--shadow-sm-dark, rgba(0,0,0,0.25));
+  }
+  
+  .cardLink:hover {
+    box-shadow: 0 4px 16px var(--shadow-brand-dark, rgba(14,165,233,0.25));
+  }
+  
+  .icon {
+    background: var(--surface-weak-dark, #0f172a);
+  }
+  
+  .title {
+    color: var(--text-primary-dark, #e2e8f0);
+  }
+  
+  .description {
+    color: var(--text-secondary-dark, #94a3b8);
+  }
+}

--- a/components/CardLink.tsx
+++ b/components/CardLink.tsx
@@ -1,0 +1,34 @@
+import Link from 'next/link';
+import s from './CardLink.module.css';
+
+interface CardLinkProps {
+  href: string;
+  title: string;
+  description?: string;
+  icon?: React.ReactNode;
+  className?: string;
+  onClick?: () => void;
+}
+
+export default function CardLink({ 
+  href, 
+  title, 
+  description, 
+  icon, 
+  className = '',
+  onClick
+}: CardLinkProps) {
+  return (
+    <Link 
+      href={href} 
+      className={`${s.cardLink} ${className}`}
+      onClick={onClick}
+    >
+      {icon && <div className={s.icon}>{icon}</div>}
+      <div className={s.content}>
+        <h3 className={s.title}>{title}</h3>
+        {description && <p className={s.description}>{description}</p>}
+      </div>
+    </Link>
+  );
+}

--- a/components/CategoryHub.module.css
+++ b/components/CategoryHub.module.css
@@ -1,0 +1,79 @@
+.categoryHub {
+  margin: 1.5rem 0;
+}
+
+.categories {
+  display: flex;
+  gap: 0.5rem;
+  overflow-x: auto;
+  padding: 0.5rem 0;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.categories::-webkit-scrollbar {
+  display: none;
+}
+
+.categoryItem {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  background: var(--surface-primary, #fff);
+  border: 1px solid var(--border-light, rgba(2,8,23,0.08));
+  border-radius: var(--radius-full, 9999px);
+  text-decoration: none;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text-secondary, #6b7280);
+  transition: all 0.2s ease;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.categoryItem:hover {
+  border-color: var(--brand-primary, #0ea5e9);
+  background: var(--brand-bg-light, rgba(14,165,233,0.05));
+  color: var(--brand-primary, #0ea5e9);
+  transform: translateY(-1px);
+}
+
+.categoryItem.active {
+  background: var(--brand-primary, #0ea5e9);
+  border-color: var(--brand-primary, #0ea5e9);
+  color: #fff;
+}
+
+.icon {
+  font-size: 1rem;
+}
+
+.label {
+  font-weight: 600;
+}
+
+@media (max-width: 768px) {
+  .categoryItem {
+    padding: 0.625rem 0.875rem;
+    font-size: 0.8125rem;
+  }
+  
+  .icon {
+    font-size: 0.875rem;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .categoryItem {
+    background: var(--surface-primary-dark, #0b1324);
+    border-color: var(--border-light-dark, rgba(148,163,184,0.2));
+    color: var(--text-secondary-dark, #94a3b8);
+  }
+  
+  .categoryItem:hover {
+    background: var(--brand-bg-dark, rgba(14,165,233,0.15));
+    border-color: var(--brand-primary, #0ea5e9);
+    color: var(--brand-primary, #0ea5e9);
+  }
+}

--- a/components/CategoryHub.tsx
+++ b/components/CategoryHub.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import s from './CategoryHub.module.css';
+
+interface CategoryItem {
+  label: string;
+  href: string;
+  icon?: string;
+}
+
+const categories: CategoryItem[] = [
+  { label: 'News', href: '/news', icon: '📰' },
+  { label: 'Guides', href: '/guides', icon: '📚' },
+  { label: 'Reviews', href: '/reviews', icon: '⭐' },
+  { label: 'Comparisons', href: '/best', icon: '⚖️' },
+  { label: 'Insurance', href: '/best/insurance', icon: '🛡️' },
+];
+
+interface CategoryHubProps {
+  onCategoryClick?: (category: string, href: string) => void;
+}
+
+export default function CategoryHub({ onCategoryClick }: CategoryHubProps) {
+  const pathname = usePathname();
+
+  const handleClick = (category: string, href: string) => {
+    if (onCategoryClick) {
+      onCategoryClick(category, href);
+    }
+  };
+
+  return (
+    <section className={s.categoryHub}>
+      <div className={s.categories}>
+        {categories.map((category) => {
+          const isActive = pathname === category.href || 
+            (category.href !== '/' && pathname.startsWith(category.href));
+          
+          return (
+            <Link
+              key={category.href}
+              href={category.href}
+              className={`${s.categoryItem} ${isActive ? s.active : ''}`}
+              onClick={() => handleClick(category.label, category.href)}
+            >
+              {category.icon && <span className={s.icon}>{category.icon}</span>}
+              <span className={s.label}>{category.label}</span>
+            </Link>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/components/ContentBlocks.module.css
+++ b/components/ContentBlocks.module.css
@@ -1,0 +1,40 @@
+.contentBlocks {
+  margin: 2rem 0;
+}
+
+.section {
+  margin-bottom: 3rem;
+}
+
+.cardGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.sectionLink {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--brand-primary, #0ea5e9);
+  text-decoration: none;
+  padding: 0.5rem 0;
+  transition: color 0.2s ease;
+}
+
+.sectionLink:hover {
+  color: var(--brand-dark, #0284c7);
+}
+
+@media (max-width: 768px) {
+  .cardGrid {
+    grid-template-columns: 1fr;
+    gap: 0.75rem;
+  }
+  
+  .section {
+    margin-bottom: 2rem;
+  }
+}

--- a/components/ContentBlocks.tsx
+++ b/components/ContentBlocks.tsx
@@ -1,0 +1,174 @@
+import Link from 'next/link';
+import CardLink from './CardLink';
+import SectionTitle from './SectionTitle';
+import s from './ContentBlocks.module.css';
+
+const guidesData = [
+  {
+    title: '口座開設ガイド',
+    description: 'FX・CFD業者の口座開設手順を詳しく解説',
+    href: '/guides/account-opening',
+  },
+  {
+    title: 'FX・CFD業者選びの完全ガイド',
+    description: '初心者から中級者まで、自分に最適な業者を見つける方法',
+    href: '/best/forex-brokers-jp#guide',
+  },
+  {
+    title: 'リスク管理の基本',
+    description: '投資におけるリスク管理の重要性と実践方法',
+    href: '/guides/risk-management',
+  },
+];
+
+const reviewsData = [
+  {
+    title: 'DMM証券レビュー',
+    description: '使いやすさと約定品質を検証',
+    href: '/reviews/dmm',
+  },
+  {
+    title: 'FXTF証券レビュー',
+    description: 'スプレッドと取引環境を詳細分析',
+    href: '/reviews/fxtf',
+  },
+  {
+    title: '松井証券レビュー',
+    description: '老舗証券会社の FX サービスを評価',
+    href: '/reviews/matsui',
+  },
+];
+
+const comparisonsData = [
+  {
+    title: 'FX・CFD業者ランキング',
+    description: '総合評価による国内業者比較',
+    href: '/best/forex-brokers-jp',
+  },
+  {
+    title: '低スプレッド業者比較',
+    description: 'コスト重視の業者選び',
+    href: '/best/low-spread',
+  },
+  {
+    title: 'アプリ・ツール比較',
+    description: '取引ツールの使いやすさを比較',
+    href: '/best/tools',
+  },
+];
+
+const insuranceData = [
+  {
+    title: '保険比較トップ',
+    description: '生命保険・医療保険・自動車保険を比較',
+    href: '/best/insurance',
+  },
+  {
+    title: '自動車保険',
+    description: '自動車保険の選び方と比較',
+    href: '/best/insurance/car',
+  },
+  {
+    title: '生命保険',
+    description: '生命保険の基本と選び方',
+    href: '/best/insurance/life',
+  },
+  {
+    title: '医療保険',
+    description: '医療保険の比較とおすすめ',
+    href: '/best/insurance/medical',
+  },
+];
+
+interface ContentBlockProps {
+  onCardClick?: (section: string, target: string) => void;
+}
+
+export default function ContentBlocks({ onCardClick }: ContentBlockProps) {
+  const handleCardClick = (section: string, href: string, title: string) => {
+    if (onCardClick) {
+      onCardClick(section, `${title} (${href})`);
+    }
+  };
+
+  return (
+    <div className={s.contentBlocks}>
+      {/* Guides Section */}
+      <section className={s.section}>
+        <SectionTitle>Guides</SectionTitle>
+        <div className={s.cardGrid}>
+          {guidesData.map((guide) => (
+            <CardLink
+              key={guide.href}
+              href={guide.href}
+              title={guide.title}
+              description={guide.description}
+              icon="📚"
+              onClick={() => handleCardClick('guides', guide.href, guide.title)}
+            />
+          ))}
+        </div>
+        <Link href="/guides" className={s.sectionLink}>
+          すべてのガイドを見る →
+        </Link>
+      </section>
+
+      {/* Reviews Section */}
+      <section className={s.section}>
+        <SectionTitle>Reviews</SectionTitle>
+        <div className={s.cardGrid}>
+          {reviewsData.map((review) => (
+            <CardLink
+              key={review.href}
+              href={review.href}
+              title={review.title}
+              description={review.description}
+              icon="⭐"
+              onClick={() => handleCardClick('reviews', review.href, review.title)}
+            />
+          ))}
+        </div>
+        <Link href="/reviews" className={s.sectionLink}>
+          すべてのレビューを見る →
+        </Link>
+      </section>
+
+      {/* Comparisons Section */}
+      <section className={s.section}>
+        <SectionTitle>Comparisons</SectionTitle>
+        <div className={s.cardGrid}>
+          {comparisonsData.map((comparison) => (
+            <CardLink
+              key={comparison.href}
+              href={comparison.href}
+              title={comparison.title}
+              description={comparison.description}
+              icon="⚖️"
+              onClick={() => handleCardClick('comparisons', comparison.href, comparison.title)}
+            />
+          ))}
+        </div>
+        <Link href="/best" className={s.sectionLink}>
+          すべての比較を見る →
+        </Link>
+      </section>
+
+      {/* Insurance Section */}
+      <section className={s.section}>
+        <SectionTitle>Insurance</SectionTitle>
+        <div className={s.cardGrid}>
+          {insuranceData.map((insurance) => (
+            <CardLink
+              key={insurance.href}
+              href={insurance.href}
+              title={insurance.title}
+              description={insurance.description}
+              icon="🛡️"
+              onClick={() => handleCardClick('insurance', insurance.href, insurance.title)}
+            />
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/components/QuickLinks.module.css
+++ b/components/QuickLinks.module.css
@@ -1,0 +1,55 @@
+.quickLinks {
+  margin: 1rem 0 2rem 0;
+  padding: 1rem;
+  background: var(--surface-weak, #f8fafc);
+  border-radius: var(--radius-lg, 16px);
+  border: 1px solid var(--border-light, rgba(2,8,23,0.06));
+}
+
+.title {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text-secondary, #6b7280);
+  margin: 0 0 0.75rem 0;
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
+}
+
+.links {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.link {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--brand-primary, #0ea5e9);
+  text-decoration: none;
+  padding: 0.25rem 0;
+  border-bottom: 1px solid transparent;
+  transition: all 0.2s ease;
+}
+
+.link:hover {
+  color: var(--brand-dark, #0284c7);
+  border-bottom-color: var(--brand-primary, #0ea5e9);
+}
+
+@media (max-width: 768px) {
+  .links {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .quickLinks {
+    background: var(--surface-weak-dark, #0f172a);
+    border-color: var(--border-light-dark, rgba(148,163,184,0.15));
+  }
+  
+  .title {
+    color: var(--text-secondary-dark, #94a3b8);
+  }
+}

--- a/components/QuickLinks.tsx
+++ b/components/QuickLinks.tsx
@@ -1,0 +1,33 @@
+import Link from 'next/link';
+import s from './QuickLinks.module.css';
+
+interface QuickLink {
+  label: string;
+  href: string;
+}
+
+const quickLinks: QuickLink[] = [
+  { label: '口座開設ガイド', href: '/guides/account-opening' },
+  { label: '比較一覧', href: '/best' },
+  { label: '保険トップ', href: '/best/insurance' },
+  { label: 'レビュー', href: '/reviews' },
+];
+
+export default function QuickLinks() {
+  return (
+    <section className={s.quickLinks}>
+      <h3 className={s.title}>Quick Links</h3>
+      <div className={s.links}>
+        {quickLinks.map((link) => (
+          <Link
+            key={link.href}
+            href={link.href}
+            className={s.link}
+          >
+            {link.label}
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/components/SectionTitle.module.css
+++ b/components/SectionTitle.module.css
@@ -1,0 +1,17 @@
+.sectionTitle {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--text-primary, #0b1324);
+  margin: 0 0 1rem 0;
+  line-height: 1.3;
+}
+
+.sectionTitle:where(h3) {
+  font-size: 1.125rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  .sectionTitle {
+    color: var(--text-primary-dark, #e2e8f0);
+  }
+}

--- a/components/SectionTitle.tsx
+++ b/components/SectionTitle.tsx
@@ -1,0 +1,21 @@
+import s from './SectionTitle.module.css';
+
+interface SectionTitleProps {
+  children: React.ReactNode;
+  className?: string;
+  level?: 'h1' | 'h2' | 'h3';
+}
+
+export default function SectionTitle({ 
+  children, 
+  className = '', 
+  level = 'h2' 
+}: SectionTitleProps) {
+  const Component = level;
+  
+  return (
+    <Component className={`${s.sectionTitle} ${className}`}>
+      {children}
+    </Component>
+  );
+}

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -5,3 +5,18 @@ export const gaEvent = (name: string, params: GAParams = {}) => {
   const w = window as any
   if (w?.gtag) w.gtag('event', name, params)
 }
+
+// Specific tracking functions for home page
+export function trackHomeHubClick(section: string, target: string) {
+  gaEvent('home_hub_click', {
+    section,
+    target
+  });
+}
+
+export function trackNewsItemClick(title: string, source: string) {
+  gaEvent('news_item_click', {
+    news_title: title,
+    news_source: source
+  });
+}


### PR DESCRIPTION
- Added CategoryHub with News/Guides/Reviews/Comparisons/Insurance links
- Implemented two-column layout: news left, content blocks right
- Created reusable SectionTitle and CardLink components
- Added ContentBlocks with 4 sections (Guides/Reviews/Comparisons/Insurance)
- Integrated QuickLinks component for top destinations
- Enhanced analytics with home_hub_click GA4 events
- Provider filtering already exists on /news with chips
- Responsive design: mobile falls back to single column

Components added:
- CategoryHub: icon-based navigation strip
- ContentBlocks: organized content sections
- CardLink: consistent card styling
- SectionTitle: unified typography
- QuickLinks: quick access links

Build: 0 warnings, home page 832B → 1.65kB, 38 pages generated