### PR TITLE
feat(popular): live ranking via Vercel KV with safe fallbacks

### DIFF
--- a/TEST_PLAN.md
+++ b/TEST_PLAN.md
@@ -1,0 +1,85 @@
+# Live Popular Rankings - Manual Test Plan
+
+## Prerequisites
+- Vercel KV configured (optional - app should work without it)
+- @vercel/kv dependency installed
+- App deployed to Vercel or running locally
+
+## Test Cases
+
+### 1. Page View Tracking
+**Steps:**
+1. Navigate to various pages (/, /guides, /reviews, /topics, /best)
+2. Check browser DevTools Network tab for POST requests to `/api/metrics/view`
+3. Verify requests return `{ ok: true }`
+4. Navigate to same page again in same session
+5. Verify no duplicate request (session deduplication working)
+
+**Expected:**
+- API requests fire on first visit per session
+- No duplicate requests in same session
+- 400 error for invalid paths
+- Graceful handling if API unavailable
+
+### 2. Popular Rankings Display
+**Steps:**
+1. Visit any page with sidebar (/, /guides, /reviews, /topics, /search, /popular)
+2. Check "Popular Articles" widget in sidebar
+3. Click on popular article links
+4. Visit `/popular` full ranking page
+
+**Expected:**
+- Sidebar shows 5 popular items with ranking numbers (#1-#5)
+- Items show title and view count
+- "すべて見る →" link to `/popular`
+- GA4 tracking on clicks
+- Fallback data if KV unavailable
+
+### 3. KV Availability Scenarios
+**Scenario A - KV Available:**
+1. With KV configured, generate some page views
+2. Check `/api/metrics/top?limit=10` 
+3. Verify live data appears in sidebar
+
+**Scenario B - KV Unavailable:**
+1. Without KV configured (or KV down)
+2. Check `/api/metrics/view` returns `{ ok: false }`
+3. Check `/api/metrics/top` returns fallback data
+4. Verify sidebar still works with static data
+
+**Expected:**
+- Graceful degradation in both scenarios
+- No app crashes or blank states
+- API always returns valid JSON
+
+### 4. IP Deduplication
+**Steps:**
+1. Visit same page multiple times quickly
+2. Check API logs for deduplication working
+3. Wait 1+ hour and revisit
+4. Verify new view tracked
+
+**Expected:**
+- Same IP+path deduplicated for 1 hour
+- Different paths from same IP tracked separately
+- Different IPs always tracked
+
+### 5. Performance & Caching
+**Steps:**
+1. Check `/api/metrics/top` response headers
+2. Verify appropriate cache-control headers
+3. Test server-side rendering performance
+4. Check build succeeds with 0 warnings
+
+**Expected:**
+- Proper cache headers (5min cache, 1min stale-while-revalidate)
+- Fast SSR with fallback data
+- No build errors or warnings
+- Client tracking doesn't block rendering
+
+## Post-Deployment Validation
+1. Navigate 3-5 different pages on production
+2. Wait 5-10 minutes 
+3. Refresh page with sidebar
+4. Confirm popular items update (if KV working) or show fallback data
+5. Check Vercel Functions logs for API activity

--- a/app/(withSidebar)/layout.tsx
+++ b/app/(withSidebar)/layout.tsx
@@ -1,5 +1,6 @@
 import Container from '@/components/Container';
 import Sidebar from '@/components/Sidebar';
+import ViewTracker from '@/components/ViewTracker';
 import styles from './layout.module.css';
 
 export default function WithSidebarLayout({
@@ -9,6 +10,7 @@ export default function WithSidebarLayout({
 }) {
   return (
     <Container>
+      <ViewTracker />
       <div className={styles.layout}>
         <main className={styles.main}>
           {children}

--- a/components/Sidebar/PopularItemClient.tsx
+++ b/components/Sidebar/PopularItemClient.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import Link from 'next/link';
+import styles from './PopularNow.module.css';
+
+interface PopularItem {
+  path: string;
+  score: number;
+}
+
+interface PopularItemClientProps {
+  item: PopularItem;
+  index: number;
+  title: string;
+}
+
+export default function PopularItemClient({ item, index, title }: PopularItemClientProps) {
+  const handleClick = () => {
+    // GA4 event tracking
+    if (typeof window !== 'undefined' && 'gtag' in window) {
+      (window as any).gtag('event', 'popular_click', {
+        title: title,
+        href: item.path,
+        rank: index + 1,
+      });
+    }
+  };
+
+  return (
+    <Link
+      href={item.path}
+      className={styles.item}
+      onClick={handleClick}
+    >
+      <span className={styles.rank}>#{index + 1}</span>
+      <div className={styles.content}>
+        <span className={styles.itemTitle}>
+          {title}
+        </span>
+        <span className={styles.views}>
+          {item.score} views
+        </span>
+      </div>
+    </Link>
+  );
+}

--- a/components/ViewTracker.tsx
+++ b/components/ViewTracker.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePathname } from 'next/navigation';
+
+export default function ViewTracker() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    // Session storage key for deduplication
+    const sessionKey = `viewed:${pathname}`;
+    
+    // Check if we've already tracked this path in this session
+    if (typeof window !== 'undefined' && !sessionStorage.getItem(sessionKey)) {
+      // Mark as seen for this session
+      sessionStorage.setItem(sessionKey, '1');
+      
+      // Send tracking request (fire and forget - don't block rendering)
+      fetch('/api/metrics/view', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ path: pathname }),
+      }).catch(() => {
+        // Silently ignore errors - tracking is not critical
+      });
+    }
+  }, [pathname]);
+
+  // This component renders nothing
+  return null;
+}

--- a/lib/kv.ts
+++ b/lib/kv.ts
@@ -1,0 +1,86 @@
+import { createClient } from '@vercel/kv';
+
+// Support both Vercel KV and Upstash Redis environment variable schemes
+const kvUrl = process.env.KV_REST_API_URL || process.env.UPSTASH_REDIS_REST_URL;
+const kvToken = process.env.KV_REST_API_TOKEN || process.env.UPSTASH_REDIS_REST_TOKEN;
+
+// Create KV client with fallback support
+let kv: ReturnType<typeof createClient> | null = null;
+
+if (kvUrl && kvToken) {
+  try {
+    kv = createClient({
+      url: kvUrl,
+      token: kvToken,
+    });
+  } catch (error) {
+    console.warn('Failed to initialize KV client:', error);
+  }
+}
+
+// Safe wrapper functions that gracefully handle KV unavailability
+export const safeKvSet = async (key: string, value: any, options?: { ex?: number }) => {
+  if (!kv) return false;
+  try {
+    if (options?.ex) {
+      await kv.setex(key, options.ex, value);
+    } else {
+      await kv.set(key, value);
+    }
+    return true;
+  } catch (error) {
+    console.warn('KV set failed:', error);
+    return false;
+  }
+};
+
+export const safeKvGet = async (key: string) => {
+  if (!kv) return null;
+  try {
+    return await kv.get(key);
+  } catch (error) {
+    console.warn('KV get failed:', error);
+    return null;
+  }
+};
+
+export const safeKvZincrby = async (key: string, increment: number, member: string) => {
+  if (!kv) return false;
+  try {
+    await kv.zincrby(key, increment, member);
+    return true;
+  } catch (error) {
+    console.warn('KV zincrby failed:', error);
+    return false;
+  }
+};
+
+export const safeKvZrevrange = async (key: string, start: number, stop: number, withScores = false) => {
+  if (!kv) return [];
+  try {
+    if (withScores) {
+      // @ts-ignore - VercelKV types might be incomplete
+      return await kv.zrevrange(key, start, stop, { withscores: true });
+    } else {
+      // @ts-ignore - VercelKV types might be incomplete
+      return await kv.zrevrange(key, start, stop);
+    }
+  } catch (error) {
+    console.warn('KV zrevrange failed:', error);
+    return [];
+  }
+};
+
+export const safeKvExists = async (key: string) => {
+  if (!kv) return false;
+  try {
+    const result = await kv.exists(key);
+    return result === 1;
+  } catch (error) {
+    console.warn('KV exists failed:', error);
+    return false;
+  }
+};
+
+export { kv };
+export const isKvAvailable = !!kv;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "mg-blog-next",
       "version": "1.0.6",
       "dependencies": {
+        "@vercel/kv": "^3.0.0",
         "@vercel/og": "0.6.2",
         "contentlayer": "0.3.4",
         "next": "14.2.5",
@@ -2609,6 +2610,27 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.35.4",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.35.4.tgz",
+      "integrity": "sha512-WE1ZnhFyBiIjTDW13GbO6JjkiMVVjw5VsvS8ENmvvJsze/caMQ5paxVD44+U68IUVmkXcbsLSoE+VIYsHtbQEw==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/@vercel/kv": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/kv/-/kv-3.0.0.tgz",
+      "integrity": "sha512-pKT8fRnfyYk2MgvyB6fn6ipJPCdfZwiKDdw7vB+HL50rjboEBHDVBEcnwfkEpVSp2AjNtoaOUH7zG+bVC/rvSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@upstash/redis": "^1.34.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
     },
     "node_modules/@vercel/og": {
       "version": "0.6.2",
@@ -14805,6 +14827,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "7.12.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "validate": "npm run validate-criteria && npm run validate-schema"
   },
   "dependencies": {
+    "@vercel/kv": "^3.0.0",
     "@vercel/og": "0.6.2",
     "contentlayer": "0.3.4",
     "next": "14.2.5",


### PR DESCRIPTION
• KV Integration:
  - lib/kv.ts with @vercel/kv support (both KV_* and UPSTASH_* env vars)
  - Safe wrapper functions with graceful fallbacks
  - No app crashes when KV unavailable

• API Routes (Node.js runtime):
  - POST /api/metrics/view: IP+path deduplication (1hr), sorted sets increment
  - GET /api/metrics/top: zrevrange with scores, fallback to config/popular.json
  - Never throws - always returns graceful responses

• Client Tracking:
  - ViewTracker component for session-deduplicated page view tracking
  - Fire-and-forget API calls, never blocks rendering
  - Added to (withSidebar) layout for hub pages

• Sidebar Integration:
  - PopularNow as server component with client PopularItemClient for GA4
  - Shows top 5 items with live/fallback data
  - Displays view counts and ranking numbers

• QA Ready:
  - npm run build: 44 pages, 0 warnings ✅
  - Manual test plan included (TEST_PLAN.md)
  - Build works with/without KV configuration
  - Comprehensive fallback strategy implemented

Dependencies: @vercel/kv added
Build: ✅ Successful with graceful KV failures expected