### PR TITLE
feat(markets): Create market widgets with FX/indices data

### DIFF
--- a/app/api/market-data/route.ts
+++ b/app/api/market-data/route.ts
@@ -1,0 +1,88 @@
+// app/api/market-data/route.ts
+import { NextResponse } from 'next/server';
+import { getMarketData } from '@/lib/market-data';
+
+export const runtime = 'edge';
+
+// Cache for 120 seconds with 60 seconds stale-while-revalidate
+const CACHE_TTL = 120;
+const SWR_TTL = 60;
+
+export async function GET() {
+  try {
+    // Get market data from placeholder function
+    const data = await getMarketData();
+    
+    // Set cache headers for edge caching
+    const headers = new Headers({
+      'Content-Type': 'application/json',
+      'Cache-Control': `public, max-age=${CACHE_TTL}, stale-while-revalidate=${SWR_TTL}`,
+      'CDN-Cache-Control': `public, max-age=${CACHE_TTL}, stale-while-revalidate=${SWR_TTL}`,
+      'Vercel-CDN-Cache-Control': `public, max-age=${CACHE_TTL}, stale-while-revalidate=${SWR_TTL}`,
+    });
+
+    return new NextResponse(JSON.stringify(data), {
+      status: 200,
+      headers,
+    });
+  } catch (error) {
+    console.error('Market data API error:', error);
+    
+    // Return fallback data with shorter cache time
+    const fallbackData = {
+      fx: [
+        {
+          symbol: 'USD/JPY',
+          rate: 150.00,
+          change: 0.00,
+          changePercent: 0.00,
+          timestamp: new Date().toISOString(),
+        },
+        {
+          symbol: 'EUR/JPY',
+          rate: 162.50,
+          change: 0.00,
+          changePercent: 0.00,
+          timestamp: new Date().toISOString(),
+        },
+      ],
+      indices: [
+        {
+          symbol: 'N225',
+          name: '日経平均株価',
+          value: 38500,
+          change: 0.00,
+          changePercent: 0.00,
+          timestamp: new Date().toISOString(),
+        },
+        {
+          symbol: 'TOPIX',
+          name: 'TOPIX',
+          value: 2650,
+          change: 0.00,
+          changePercent: 0.00,
+          timestamp: new Date().toISOString(),
+        },
+        {
+          symbol: 'SPX',
+          name: 'S&P 500',
+          value: 5620,
+          change: 0.00,
+          changePercent: 0.00,
+          timestamp: new Date().toISOString(),
+        },
+      ],
+      lastUpdated: new Date().toISOString(),
+    };
+
+    const headers = new Headers({
+      'Content-Type': 'application/json',
+      'Cache-Control': 'public, max-age=30, stale-while-revalidate=15',
+    });
+
+    return new NextResponse(JSON.stringify(fallbackData), {
+      status: 200,
+      headers,
+    });
+  }
+}

--- a/app/home.module.css
+++ b/app/home.module.css
@@ -90,6 +90,11 @@
   }
 }
 
+/* Market Section */
+.marketSection {
+  margin: 24px 0;
+}
+
 @media (max-width: 820px) {
   .grid { grid-template-columns: 1fr; }
   

--- a/app/markets/page.module.css
+++ b/app/markets/page.module.css
@@ -1,0 +1,188 @@
+/* Markets page styles */
+.container {
+  padding: 2rem 0;
+}
+
+.header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.title {
+  font-size: 2.25rem;
+  font-weight: 700;
+  color: #1f2937;
+  margin-bottom: 1rem;
+  line-height: 1.2;
+}
+
+.description {
+  font-size: 1.125rem;
+  color: #6b7280;
+  max-width: 600px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+.marketSection {
+  margin-bottom: 3rem;
+}
+
+.explainerSection {
+  margin-bottom: 3rem;
+}
+
+.sectionTitle {
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: #1f2937;
+  margin-bottom: 2rem;
+  text-align: center;
+}
+
+.explainerGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 1.5rem;
+  margin-top: 2rem;
+}
+
+.explainerCard {
+  background: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 1.5rem;
+  transition: all 0.3s ease;
+}
+
+.explainerCard:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.1);
+  border-color: #3b82f6;
+}
+
+.cardTitle {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #1f2937;
+  margin-bottom: 0.75rem;
+}
+
+.cardDescription {
+  color: #6b7280;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.disclaimerSection {
+  background: #fef3c7;
+  border: 1px solid #f59e0b;
+  border-radius: 8px;
+  padding: 1.5rem;
+  margin-top: 2rem;
+}
+
+.disclaimerTitle {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: #92400e;
+  margin-bottom: 0.75rem;
+}
+
+.disclaimerText {
+  color: #92400e;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  margin: 0;
+}
+
+/* Responsive design */
+@media (max-width: 768px) {
+  .container {
+    padding: 1.5rem 0;
+  }
+  
+  .title {
+    font-size: 1.875rem;
+  }
+  
+  .description {
+    font-size: 1rem;
+  }
+  
+  .explainerGrid {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+  
+  .explainerCard {
+    padding: 1.25rem;
+  }
+  
+  .disclaimerSection {
+    padding: 1.25rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .title {
+    font-size: 1.5rem;
+  }
+  
+  .sectionTitle {
+    font-size: 1.5rem;
+  }
+  
+  .explainerCard {
+    padding: 1rem;
+  }
+  
+  .disclaimerSection {
+    padding: 1rem;
+  }
+}
+
+/* Dark mode support */
+@media (prefers-color-scheme: dark) {
+  .title {
+    color: #f9fafb;
+  }
+  
+  .description {
+    color: #d1d5db;
+  }
+  
+  .sectionTitle {
+    color: #f9fafb;
+  }
+  
+  .explainerCard {
+    background: #1f2937;
+    border-color: #374151;
+  }
+  
+  .explainerCard:hover {
+    border-color: #60a5fa;
+  }
+  
+  .cardTitle {
+    color: #f9fafb;
+  }
+  
+  .cardDescription {
+    color: #d1d5db;
+  }
+  
+  .disclaimerSection {
+    background: #451a03;
+    border-color: #92400e;
+  }
+  
+  .disclaimerTitle {
+    color: #fbbf24;
+  }
+  
+  .disclaimerText {
+    color: #fbbf24;
+  }
+}

--- a/app/markets/page.tsx
+++ b/app/markets/page.tsx
@@ -1,0 +1,110 @@
+import type { Metadata } from 'next';
+import Container from '@/components/Container';
+import JsonLd from '@/components/JsonLd';
+import JsonLdBreadcrumbs from '@/components/JsonLdBreadcrumbs';
+import Breadcrumbs from '@/components/Breadcrumbs';
+import PrRibbon from '@/components/PrRibbon';
+import MarketTicker from '@/components/MarketTicker';
+import { getMarketData } from '@/lib/market-data';
+import styles from './page.module.css';
+
+export const metadata: Metadata = {
+  title: 'リアルタイム市況・相場情報 | 為替・株価指数 | Marlow Gate',
+  description: 'USD/JPY、EUR/JPY、日経平均株価、TOPIX、S&P500などの最新相場情報をリアルタイムで提供。投資判断にお役立てください。',
+  openGraph: {
+    title: 'リアルタイム市況・相場情報 | 為替・株価指数',
+    description: 'USD/JPY、EUR/JPY、日経平均株価、TOPIX、S&P500などの最新相場情報をリアルタイムで提供',
+    type: 'website',
+    url: 'https://marlowgate.com/markets',
+  },
+  alternates: {
+    canonical: 'https://marlowgate.com/markets',
+  },
+};
+
+// Cache for 2 minutes
+export const revalidate = 120;
+
+export default async function MarketsPage() {
+  // Pre-fetch market data for initial render
+  let initialData = null;
+  try {
+    initialData = await getMarketData();
+  } catch (error) {
+    // Fallback data will be used by the component
+    console.warn('Failed to pre-fetch market data:', error);
+  }
+
+  const jsonLdData = {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "リアルタイム市況・相場情報",
+    "description": "USD/JPY、EUR/JPY、日経平均株価、TOPIX、S&P500などの最新相場情報をリアルタイムで提供",
+    "url": "https://marlowgate.com/markets"
+  };
+
+  return (
+    <>
+      <JsonLd data={jsonLdData} />
+      <JsonLdBreadcrumbs />
+      <PrRibbon />
+      
+      <Container>
+        <Breadcrumbs items={[
+          { name: 'ホーム', href: '/' },
+          { name: '市況情報' }
+        ]} />
+
+        <div className={styles.container}>
+          <header className={styles.header}>
+            <h1 className={styles.title}>リアルタイム市況・相場情報</h1>
+            <p className={styles.description}>
+              主要通貨ペアおよび株価指数の最新相場情報をリアルタイムで提供します。
+              投資判断の参考にご活用ください。
+            </p>
+          </header>
+
+          <section className={styles.marketSection}>
+            <MarketTicker initialData={initialData} limit={10} showTitle={false} />
+          </section>
+
+          <section className={styles.explainerSection}>
+            <h2 className={styles.sectionTitle}>市況データについて</h2>
+            <div className={styles.explainerGrid}>
+              <div className={styles.explainerCard}>
+                <h3 className={styles.cardTitle}>為替相場</h3>
+                <p className={styles.cardDescription}>
+                  USD/JPY（米ドル円）、EUR/JPY（ユーロ円）など主要通貨ペアのリアルタイムレートを表示。
+                  前日比の変動率も併せて確認できます。
+                </p>
+              </div>
+              <div className={styles.explainerCard}>
+                <h3 className={styles.cardTitle}>株価指数</h3>
+                <p className={styles.cardDescription}>
+                  日経平均株価、TOPIX、S&P 500など代表的な株価指数の現在値と変動率を表示。
+                  市場の全体的な動向を把握できます。
+                </p>
+              </div>
+              <div className={styles.explainerCard}>
+                <h3 className={styles.cardTitle}>更新頻度</h3>
+                <p className={styles.cardDescription}>
+                  データは2分間隔で自動更新されます。最新の市況状況を常に確認いただけます。
+                  ネットワークエラー時は安全なフォールバックデータを表示します。
+                </p>
+              </div>
+            </div>
+          </section>
+
+          <section className={styles.disclaimerSection}>
+            <h3 className={styles.disclaimerTitle}>免責事項</h3>
+            <p className={styles.disclaimerText}>
+              表示される相場情報は参考情報であり、投資助言や取引の推奨を目的としたものではありません。
+              投資判断は必ずご自身の責任で行ってください。当サイトは情報の正確性を保証するものではなく、
+              投資結果について一切の責任を負いません。
+            </p>
+          </section>
+        </div>
+      </Container>
+    </>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@ import { headers } from 'next/headers'
 import NewsItemClient from '@/components/NewsItemClient'
 import Popular from '@/components/Popular'
 import Sidebar from '@/components/Sidebar'
+import MarketTicker from '@/components/MarketTicker'
 import popularItems from '@/config/popular.json'
 import s from './home.module.css'
 
@@ -73,6 +74,11 @@ export default async function Page() {
       {/* Two-column layout */}
       <div className={s.mainContent}>
         <div className={s.primaryColumn}>
+          {/* Market Ticker Section */}
+          <section className={s.marketSection}>
+            <MarketTicker limit={5} showTitle={true} />
+          </section>
+
           {/* Latest Market News Section */}
           {items.length > 0 ? (
             <section className={s.newsSection}>

--- a/components/MarketTicker.module.css
+++ b/components/MarketTicker.module.css
@@ -1,0 +1,241 @@
+/* MarketTicker.module.css */
+.container {
+  background: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+  min-height: 200px; /* Fixed height to prevent layout shift */
+}
+
+.title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: #1f2937;
+  margin: 0 0 1rem 0;
+  border-bottom: 2px solid #3b82f6;
+  padding-bottom: 0.5rem;
+}
+
+.ticker {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem;
+  background: #f9fafb;
+  border-radius: 6px;
+  transition: background-color 0.2s ease;
+  min-height: 60px; /* Fixed height to prevent layout shift */
+}
+
+.item:hover {
+  background: #f3f4f6;
+}
+
+.itemHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.symbol {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #374151;
+}
+
+.name {
+  font-size: 0.75rem;
+  color: #6b7280;
+}
+
+.itemData {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.25rem;
+}
+
+.value {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.change {
+  font-size: 0.75rem;
+  font-weight: 500;
+  padding: 0.125rem 0.375rem;
+  border-radius: 4px;
+  min-width: 50px; /* Fixed width to prevent layout shift */
+  text-align: center;
+}
+
+.positive {
+  background: #dcfce7;
+  color: #16a34a;
+}
+
+.negative {
+  background: #fef2f2;
+  color: #dc2626;
+}
+
+.timestamp {
+  font-size: 0.75rem;
+  color: #9ca3af;
+  text-align: center;
+  margin-top: 0.75rem;
+  border-top: 1px solid #e5e7eb;
+  padding-top: 0.75rem;
+}
+
+.error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 120px;
+  gap: 0.5rem;
+}
+
+.errorIcon {
+  font-size: 1.5rem;
+}
+
+.errorText {
+  font-size: 0.875rem;
+  color: #6b7280;
+  text-align: center;
+}
+
+/* Skeleton loading styles */
+.skeleton {
+  pointer-events: none;
+}
+
+.skeletonText {
+  background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
+  background-size: 200% 100%;
+  animation: loading 1.5s infinite;
+  border-radius: 4px;
+  color: transparent !important;
+}
+
+.skeleton .symbol.skeletonText {
+  width: 60px;
+  height: 14px;
+}
+
+.skeleton .name.skeletonText {
+  width: 80px;
+  height: 12px;
+}
+
+.skeleton .value.skeletonText {
+  width: 70px;
+  height: 16px;
+}
+
+.skeleton .change.skeletonText {
+  width: 50px;
+  height: 12px;
+}
+
+.timestamp.skeletonText {
+  width: 120px;
+  height: 12px;
+  margin: 0.75rem auto 0;
+}
+
+@keyframes loading {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  .container {
+    padding: 0.75rem;
+    min-height: 180px;
+  }
+  
+  .item {
+    padding: 0.5rem;
+    min-height: 50px;
+  }
+  
+  .symbol {
+    font-size: 0.8125rem;
+  }
+  
+  .value {
+    font-size: 0.9375rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .container {
+    padding: 0.5rem;
+  }
+  
+  .ticker {
+    gap: 0.5rem;
+  }
+  
+  .item {
+    padding: 0.5rem;
+    min-height: 45px;
+  }
+}
+
+/* Dark mode support */
+@media (prefers-color-scheme: dark) {
+  .container {
+    background: #1f2937;
+    border-color: #374151;
+  }
+  
+  .title {
+    color: #f9fafb;
+    border-bottom-color: #60a5fa;
+  }
+  
+  .item {
+    background: #374151;
+  }
+  
+  .item:hover {
+    background: #4b5563;
+  }
+  
+  .symbol {
+    color: #e5e7eb;
+  }
+  
+  .name {
+    color: #9ca3af;
+  }
+  
+  .value {
+    color: #f9fafb;
+  }
+  
+  .timestamp {
+    color: #6b7280;
+    border-top-color: #4b5563;
+  }
+  
+  .errorText {
+    color: #9ca3af;
+  }
+}

--- a/components/MarketTicker.tsx
+++ b/components/MarketTicker.tsx
@@ -1,0 +1,148 @@
+// components/MarketTicker.tsx
+'use client';
+import { useEffect, useState } from 'react';
+import { MarketData } from '@/lib/market-data';
+import styles from './MarketTicker.module.css';
+
+interface MarketTickerProps {
+  initialData?: MarketData | null;
+  limit?: number;
+  showTitle?: boolean;
+}
+
+export default function MarketTicker({ initialData = null, limit = 5, showTitle = true }: MarketTickerProps) {
+  const [data, setData] = useState<MarketData | null>(initialData);
+  const [loading, setLoading] = useState(!initialData);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+
+    async function fetchData() {
+      try {
+        const response = await fetch('/api/market-data');
+        if (!response.ok) throw new Error('Failed to fetch market data');
+        
+        const marketData = await response.json();
+        if (mounted) {
+          setData(marketData);
+          setError(null);
+        }
+      } catch (err) {
+        if (mounted) {
+          setError(err instanceof Error ? err.message : 'Failed to load market data');
+        }
+      } finally {
+        if (mounted) {
+          setLoading(false);
+        }
+      }
+    }
+
+    if (!initialData) {
+      fetchData();
+    }
+
+    return () => {
+      mounted = false;
+    };
+  }, [initialData]);
+
+  if (loading) {
+    return <MarketTickerSkeleton limit={limit} showTitle={showTitle} />;
+  }
+
+  if (error || !data) {
+    return <MarketTickerError showTitle={showTitle} />;
+  }
+
+  const allItems = [
+    ...data.fx.map(item => ({
+      type: 'fx' as const,
+      symbol: item.symbol,
+      name: item.symbol,
+      value: item.rate,
+      change: item.change,
+      changePercent: item.changePercent,
+    })),
+    ...data.indices.map(item => ({
+      type: 'index' as const,
+      symbol: item.symbol,
+      name: item.name,
+      value: item.value,
+      change: item.change,
+      changePercent: item.changePercent,
+    })),
+  ].slice(0, limit);
+
+  return (
+    <div className={styles.container} aria-live="polite" aria-label="Market data ticker">
+      {showTitle && (
+        <h3 className={styles.title}>リアルタイム市況</h3>
+      )}
+      <div className={styles.ticker}>
+        {allItems.map((item, index) => (
+          <div key={`${item.symbol}-${index}`} className={styles.item}>
+            <div className={styles.itemHeader}>
+              <span className={styles.symbol}>{item.symbol}</span>
+              <span className={styles.name}>{item.name}</span>
+            </div>
+            <div className={styles.itemData}>
+              <span className={styles.value}>
+                {item.type === 'fx' ? item.value.toFixed(2) : item.value.toLocaleString()}
+              </span>
+              <span className={`${styles.change} ${item.changePercent >= 0 ? styles.positive : styles.negative}`}>
+                {item.changePercent >= 0 ? '+' : ''}{item.changePercent.toFixed(2)}%
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className={styles.timestamp}>
+        最終更新: {new Date(data.lastUpdated).toLocaleTimeString('ja-JP', { 
+          hour: '2-digit', 
+          minute: '2-digit' 
+        })}
+      </div>
+    </div>
+  );
+}
+
+function MarketTickerSkeleton({ limit, showTitle }: { limit: number; showTitle: boolean }) {
+  return (
+    <div className={styles.container} aria-label="Loading market data">
+      {showTitle && (
+        <h3 className={styles.title}>リアルタイム市況</h3>
+      )}
+      <div className={styles.ticker}>
+        {Array.from({ length: limit }, (_, index) => (
+          <div key={index} className={`${styles.item} ${styles.skeleton}`}>
+            <div className={styles.itemHeader}>
+              <span className={`${styles.symbol} ${styles.skeletonText}`}></span>
+              <span className={`${styles.name} ${styles.skeletonText}`}></span>
+            </div>
+            <div className={styles.itemData}>
+              <span className={`${styles.value} ${styles.skeletonText}`}></span>
+              <span className={`${styles.change} ${styles.skeletonText}`}></span>
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className={`${styles.timestamp} ${styles.skeletonText}`}></div>
+    </div>
+  );
+}
+
+function MarketTickerError({ showTitle }: { showTitle: boolean }) {
+  return (
+    <div className={styles.container} aria-label="Market data unavailable">
+      {showTitle && (
+        <h3 className={styles.title}>リアルタイム市況</h3>
+      )}
+      <div className={styles.error}>
+        <span className={styles.errorIcon}>⚠️</span>
+        <span className={styles.errorText}>市況データを取得できませんでした</span>
+      </div>
+    </div>
+  );
+}

--- a/lib/market-data.ts
+++ b/lib/market-data.ts
@@ -1,0 +1,85 @@
+// lib/market-data.ts - Placeholder functions for market data
+export interface FxData {
+  symbol: string;
+  rate: number;
+  change: number;
+  changePercent: number;
+  timestamp: string;
+}
+
+export interface IndexData {
+  symbol: string;
+  name: string;
+  value: number;
+  change: number;
+  changePercent: number;
+  timestamp: string;
+}
+
+export interface MarketData {
+  fx: FxData[];
+  indices: IndexData[];
+  lastUpdated: string;
+}
+
+// Placeholder function - simulate market data with realistic values
+export async function getMarketData(): Promise<MarketData> {
+  // Simulate API delay
+  await new Promise(resolve => setTimeout(resolve, 100 + Math.random() * 200));
+  
+  const now = new Date().toISOString();
+  
+  // Generate realistic FX data with small random variations
+  const baseRates = { 'USD/JPY': 150.25, 'EUR/JPY': 162.80 };
+  const fx: FxData[] = Object.entries(baseRates).map(([symbol, baseRate]) => {
+    const variation = (Math.random() - 0.5) * 2; // ±1 range
+    const rate = Number((baseRate + variation).toFixed(2));
+    const change = Number((Math.random() - 0.5).toFixed(2));
+    const changePercent = Number(((change / rate) * 100).toFixed(2));
+    
+    return {
+      symbol,
+      rate,
+      change,
+      changePercent,
+      timestamp: now,
+    };
+  });
+  
+  // Generate realistic index data
+  const baseIndices = {
+    'N225': { name: '日経平均株価', value: 38500 },
+    'TOPIX': { name: 'TOPIX', value: 2650 },
+    'SPX': { name: 'S&P 500', value: 5620 },
+  };
+  
+  const indices: IndexData[] = Object.entries(baseIndices).map(([symbol, { name, value: baseValue }]) => {
+    const variation = (Math.random() - 0.5) * (baseValue * 0.02); // ±2% variation
+    const value = Number((baseValue + variation).toFixed(2));
+    const change = Number((Math.random() - 0.5 * baseValue * 0.01).toFixed(2));
+    const changePercent = Number(((change / value) * 100).toFixed(2));
+    
+    return {
+      symbol,
+      name,
+      value,
+      change,
+      changePercent,
+      timestamp: now,
+    };
+  });
+  
+  return {
+    fx,
+    indices,
+    lastUpdated: now,
+  };
+}
+
+// Mock error for testing fallbacks
+export async function getMarketDataWithError(): Promise<MarketData> {
+  if (Math.random() < 0.1) { // 10% chance of error for testing
+    throw new Error('Market data service unavailable');
+  }
+  return getMarketData();
+}


### PR DESCRIPTION
- Add reusable MarketTicker component with skeleton loading
- Create placeholder market data API with realistic mock values
- Implement /api/market-data with edge caching (120s + 60s SWR)
- Add market ticker to home page under hero section
- Create /markets route with detailed widgets and explainer
- Support USD/JPY, EUR/JPY, Nikkei 225, TOPIX, S&P 500
- Include fixed dimensions for layout shift prevention
- Add aria-live="polite" for accessibility
- Implement safe fallback on fetch errors
- All quality gates pass with 0 TypeScript/ESLint warnings