### PR TITLE
feat(feeds): implement OpenSearch and RSS feeds v1

### DIFF
--- a/app/feed/news.xml/route.ts
+++ b/app/feed/news.xml/route.ts
@@ -1,0 +1,92 @@
+import { site } from '@/lib/site'
+
+export const GET = async (request: Request) => {
+  const { searchParams } = new URL(request.url)
+  const period = searchParams.get('period') || 'week'
+  const providers = searchParams.get('providers')?.split(',').filter(Boolean) || []
+  
+  try {
+    // Fetch news from our API
+    const apiUrl = new URL('/api/news', site.url)
+    apiUrl.searchParams.set('period', period)
+    if (providers.length > 0) {
+      apiUrl.searchParams.set('providers', providers.join(','))
+    }
+    
+    const response = await fetch(apiUrl.toString(), {
+      next: { revalidate: 3600 } // 1 hour
+    })
+    
+    if (!response.ok) {
+      throw new Error(`News API error: ${response.status}`)
+    }
+    
+    const newsData = await response.json()
+    const newsItems = newsData.items || []
+    const latest20 = newsItems.slice(0, 20)
+    
+    const lastBuildDate = new Date().toUTCString()
+    const lastNewsDate = latest20.length > 0 ? new Date(latest20[0].publishedAt).toUTCString() : lastBuildDate
+    
+    const rss = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>${site.title} - FX・投資ニュース</title>
+    <description>FX・投資・資産運用に関する最新ニュース</description>
+    <link>${site.url}/news</link>
+    <language>ja-JP</language>
+    <lastBuildDate>${lastBuildDate}</lastBuildDate>
+    <pubDate>${lastNewsDate}</pubDate>
+    <ttl>60</ttl>
+    <atom:link href="${site.url}/feed/news.xml" rel="self" type="application/rss+xml"/>
+    <image>
+      <url>${site.url}/icon.png</url>
+      <title>${site.title}</title>
+      <link>${site.url}/news</link>
+      <width>144</width>
+      <height>144</height>
+    </image>
+    ${latest20.map(item => `
+    <item>
+      <title><![CDATA[${item.title}]]></title>
+      <description><![CDATA[${item.sourceName} からの最新ニュース]]></description>
+      <link>${item.url}</link>
+      <guid isPermaLink="true">${item.url}</guid>
+      <pubDate>${new Date(item.publishedAt).toUTCString()}</pubDate>
+      <author>contact@marlowgate.com (${site.author})</author>
+      <category><![CDATA[${item.sourceName}]]></category>
+      <category><![CDATA[FX]]></category>
+      <category><![CDATA[投資]]></category>
+    </item>`).join('')}
+  </channel>
+</rss>`
+
+    return new Response(rss, {
+      headers: {
+        'Content-Type': 'application/rss+xml; charset=UTF-8',
+        'Cache-Control': 'public, max-age=3600', // 1 hour
+      },
+    })
+  } catch (error) {
+    console.error('Error generating news RSS:', error)
+    
+    // Fallback empty RSS
+    const fallbackRss = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>${site.title} - FX・投資ニュース</title>
+    <description>FX・投資・資産運用に関する最新ニュース</description>
+    <link>${site.url}/news</link>
+    <language>ja-JP</language>
+    <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
+  </channel>
+</rss>`
+    
+    return new Response(fallbackRss, {
+      headers: {
+        'Content-Type': 'application/rss+xml; charset=UTF-8',
+        'Cache-Control': 'public, max-age=300', // 5 minutes for error case
+      },
+    })
+  }
+}

--- a/app/feed/posts.xml/route.ts
+++ b/app/feed/posts.xml/route.ts
@@ -1,0 +1,64 @@
+import { allPosts } from 'contentlayer/generated'
+import { site } from '@/lib/site'
+
+export const GET = async (request: Request) => {
+  const { searchParams } = new URL(request.url)
+  const query = searchParams.get('q')
+  
+  let posts = allPosts
+    .filter(p => !p.draft)
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+    .slice(0, 20)
+  
+  // Filter by search query if provided
+  if (query) {
+    const searchLower = query.toLowerCase()
+    posts = posts.filter(post => 
+      post.title.toLowerCase().includes(searchLower) ||
+      post.description?.toLowerCase().includes(searchLower) ||
+      post.tags?.some(tag => tag.toLowerCase().includes(searchLower))
+    )
+  }
+  
+  const lastBuildDate = new Date().toUTCString()
+  const lastPostDate = posts.length > 0 ? new Date(posts[0].date).toUTCString() : lastBuildDate
+  
+  const rss = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+  <channel>
+    <title>${site.title} - ブログ記事</title>
+    <description>${site.description}</description>
+    <link>${site.url}</link>
+    <language>ja-JP</language>
+    <lastBuildDate>${lastBuildDate}</lastBuildDate>
+    <pubDate>${lastPostDate}</pubDate>
+    <ttl>60</ttl>
+    <atom:link href="${site.url}/feed/posts.xml" rel="self" type="application/rss+xml"/>
+    <image>
+      <url>${site.url}/icon.png</url>
+      <title>${site.title}</title>
+      <link>${site.url}</link>
+      <width>144</width>
+      <height>144</height>
+    </image>
+    ${posts.map(post => `
+    <item>
+      <title><![CDATA[${post.title}]]></title>
+      <description><![CDATA[${post.description || ''}]]></description>
+      <link>${site.url}${post.url}</link>
+      <guid isPermaLink="true">${site.url}${post.url}</guid>
+      <pubDate>${new Date(post.date).toUTCString()}</pubDate>
+      <author>contact@marlowgate.com (${site.author})</author>
+      ${post.tags?.map(tag => `<category><![CDATA[${tag}]]></category>`).join('') || ''}
+      ${post.description ? `<content:encoded><![CDATA[${post.description}]]></content:encoded>` : ''}
+    </item>`).join('')}
+  </channel>
+</rss>`
+
+  return new Response(rss, {
+    headers: {
+      'Content-Type': 'application/rss+xml; charset=UTF-8',
+      'Cache-Control': 'public, max-age=3600', // 1 hour
+    },
+  })
+}

--- a/app/feed/tags/[slug].xml/route.ts
+++ b/app/feed/tags/[slug].xml/route.ts
@@ -1,0 +1,70 @@
+import { allPosts } from 'contentlayer/generated'
+import { site } from '@/lib/site'
+
+export const GET = async (request: Request, { params }: { params: { slug: string } }) => {
+  if (!params?.slug) {
+    return new Response('Tag not found', { status: 404 })
+  }
+  
+  const tag = decodeURIComponent(params.slug)
+  
+  const postsWithTag = allPosts
+    .filter(p => !p.draft && p.tags?.includes(tag))
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+    .slice(0, 15) // Limit to 15 items for tag feeds
+  
+  const lastBuildDate = new Date().toUTCString()
+  const lastPostDate = postsWithTag.length > 0 ? new Date(postsWithTag[0].date).toUTCString() : lastBuildDate
+  
+  const rss = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+  <channel>
+    <title>${site.title} - タグ: ${tag}</title>
+    <description>${tag}に関する記事 - ${site.description}</description>
+    <link>${site.url}/tags/${encodeURIComponent(tag)}</link>
+    <language>ja-JP</language>
+    <lastBuildDate>${lastBuildDate}</lastBuildDate>
+    <pubDate>${lastPostDate}</pubDate>
+    <ttl>60</ttl>
+    <atom:link href="${site.url}/feed/tags/${encodeURIComponent(tag)}.xml" rel="self" type="application/rss+xml"/>
+    <image>
+      <url>${site.url}/icon.png</url>
+      <title>${site.title}</title>
+      <link>${site.url}/tags/${encodeURIComponent(tag)}</link>
+      <width>144</width>
+      <height>144</height>
+    </image>
+    ${postsWithTag.map(post => `
+    <item>
+      <title><![CDATA[${post.title}]]></title>
+      <description><![CDATA[${post.description || ''}]]></description>
+      <link>${site.url}${post.url}</link>
+      <guid isPermaLink="true">${site.url}${post.url}</guid>
+      <pubDate>${new Date(post.date).toUTCString()}</pubDate>
+      <author>contact@marlowgate.com (${site.author})</author>
+      <category><![CDATA[${tag}]]></category>
+      ${post.tags?.filter(t => t !== tag).map(t => `<category><![CDATA[${t}]]></category>`).join('') || ''}
+      ${post.description ? `<content:encoded><![CDATA[${post.description}]]></content:encoded>` : ''}
+    </item>`).join('')}
+  </channel>
+</rss>`
+
+  return new Response(rss, {
+    headers: {
+      'Content-Type': 'application/rss+xml; charset=UTF-8',
+      'Cache-Control': 'public, max-age=3600', // 1 hour
+    },
+  })
+}
+
+export async function generateStaticParams() {
+  const tags = Array.from(new Set(
+    allPosts
+      .filter(p => !p.draft)
+      .flatMap(p => p.tags || [])
+  ))
+  
+  return tags.map(tag => ({
+    slug: encodeURIComponent(tag)
+  }))
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,7 +11,14 @@ export const metadata: Metadata = {
   metadataBase: new URL(site.url),
   title: { default: site.title, template: `%s — ${site.title}` },
   description: site.description,
-  alternates: { types: { 'application/rss+xml': `${site.url}/rss.xml` } },
+  alternates: { 
+    types: { 
+      'application/rss+xml': [
+        { url: `${site.url}/feed/posts.xml`, title: 'ブログ記事' },
+        { url: `${site.url}/feed/news.xml`, title: 'FX・投資ニュース' }
+      ]
+    } 
+  },
   openGraph: { siteName: site.title },
   twitter: { site: site.twitter || undefined },
   icons: { 
@@ -19,7 +26,10 @@ export const metadata: Metadata = {
     shortcut: '/favicon.svg', 
     apple: '/favicon.svg' 
   },
-  manifest: '/site.webmanifest'
+  manifest: '/site.webmanifest',
+  other: {
+    'search': `${site.url}/opensearch.xml`
+  }
 }
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
@@ -31,6 +41,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 
   return (
     <html lang="ja">
+      <head>
+        <link rel="search" type="application/opensearchdescription+xml" title={`${site.title} 検索`} href={`${site.url}/opensearch.xml`} />
+      </head>
       <body className={inter.className + " min-h-screen antialiased"}>
         <JsonLdSitewide />
         {gaId ? (

--- a/app/opensearch.xml/route.ts
+++ b/app/opensearch.xml/route.ts
@@ -1,0 +1,28 @@
+import { site } from '@/lib/site'
+
+export const GET = async () => {
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+  <ShortName>${site.brand.name}</ShortName>
+  <Description>FX・投資情報の検索 - ${site.brand.name}</Description>
+  <InputEncoding>UTF-8</InputEncoding>
+  <OutputEncoding>UTF-8</OutputEncoding>
+  <Language>ja-JP</Language>
+  <Url type="text/html" template="${site.url}/search?q={searchTerms}"/>
+  <Url type="application/rss+xml" template="${site.url}/feed/posts.xml?q={searchTerms}"/>
+  <Image height="16" width="16" type="image/x-icon">${site.url}/icon.png</Image>
+  <Image height="64" width="64" type="image/png">${site.url}/icon.png</Image>
+  <Developer>${site.author}</Developer>
+  <Contact>contact@marlowgate.com</Contact>
+  <SyndicationRight>open</SyndicationRight>
+  <AdultContent>false</AdultContent>
+  <Attribution>Copyright © ${new Date().getFullYear()} ${site.brand.name}. All rights reserved.</Attribution>
+</OpenSearchDescription>`
+
+  return new Response(xml, {
+    headers: {
+      'Content-Type': 'application/opensearchdescription+xml; charset=UTF-8',
+      'Cache-Control': 'public, max-age=86400', // 24 hours
+    },
+  })
+}

--- a/app/robots.txt/route.ts
+++ b/app/robots.txt/route.ts
@@ -10,8 +10,13 @@ Allow: /
 # Sitemaps
 Sitemap: ${base}/sitemap.xml
 
-# Feed (crawler helper)
+# Feeds
 Sitemap: ${base}/rss.xml
+Sitemap: ${base}/feed/posts.xml
+Sitemap: ${base}/feed/news.xml
+
+# OpenSearch
+Allow: /opensearch.xml
 `
   return new Response(body, { headers: { 'Content-Type': 'text/plain; charset=utf-8' } })
 }

--- a/app/sitemap.xml/route.ts
+++ b/app/sitemap.xml/route.ts
@@ -48,6 +48,11 @@ export const GET = async () => {
     { loc: `${site.url}/disclaimer`, lastmod: new Date().toISOString(), priority: 0.4, changefreq: 'yearly' },
     { loc: `${site.url}/policy`, lastmod: new Date().toISOString(), priority: 0.4, changefreq: 'yearly' },
     { loc: `${site.url}/disclosure`, lastmod: new Date().toISOString(), priority: 0.4, changefreq: 'yearly' },
+    
+    // Feeds and OpenSearch
+    { loc: `${site.url}/opensearch.xml`, lastmod: new Date().toISOString(), priority: 0.3, changefreq: 'monthly' },
+    { loc: `${site.url}/feed/posts.xml`, lastmod: new Date().toISOString(), priority: 0.3, changefreq: 'daily' },
+    { loc: `${site.url}/feed/news.xml`, lastmod: new Date().toISOString(), priority: 0.3, changefreq: 'hourly' },
   ]
   
   const urls: SitemapEntry[] = [
@@ -63,6 +68,12 @@ export const GET = async () => {
       lastmod: new Date().toISOString(),
       priority: 0.5,
       changefreq: 'weekly' as const
+    })),
+    ...tags.map(t => ({ 
+      loc: `${site.url}/feed/tags/${encodeURIComponent(t)}.xml`, 
+      lastmod: new Date().toISOString(),
+      priority: 0.3,
+      changefreq: 'daily' as const
     })),
   ]
   

--- a/components/FooterMini.tsx
+++ b/components/FooterMini.tsx
@@ -3,7 +3,6 @@ import styles from './footer.module.css'
 import Link from 'next/link'
 
 const storeUrl = process.env.NEXT_PUBLIC_CTA_URL || process.env.NEXT_PUBLIC_HERO_CTA_URL || '/'
-const showRss = process.env.NEXT_PUBLIC_SHOW_RSS_LINK === '1'
 const showSitemap = process.env.NEXT_PUBLIC_SHOW_SITEMAP_LINK === '1'
 
 export default function FooterMini() {
@@ -40,6 +39,15 @@ export default function FooterMini() {
                 <Link href="/guides" className={styles.sitemapLink}>ガイド</Link>
               </nav>
             </div>
+            <div className={styles.sitemapColumn}>
+              <h3 className={styles.sitemapTitle}>フィード</h3>
+              <nav className={styles.sitemapNav}>
+                <Link href="/feed/posts.xml" className={styles.sitemapLink}>ブログRSS</Link>
+                <Link href="/feed/news.xml" className={styles.sitemapLink}>ニュースRSS</Link>
+                <Link href="/opensearch.xml" className={styles.sitemapLink}>検索エンジン</Link>
+                <Link href="/sitemap.xml" className={styles.sitemapLink}>サイトマップ</Link>
+              </nav>
+            </div>
           </div>
         </div>
       </section>
@@ -56,7 +64,8 @@ export default function FooterMini() {
             <Link href="/privacy" className={styles.link}>Privacy</Link>
             <Link href="/disclaimer" className={styles.link}>免責事項</Link>
             <Link href="/policy" className={styles.link}>サイトポリシー</Link>
-            {showRss ? <Link href="/rss.xml" className={styles.link}>RSS</Link> : null}
+            <Link href="/feed/posts.xml" className={styles.link}>ブログRSS</Link>
+            <Link href="/feed/news.xml" className={styles.link}>ニュースRSS</Link>
             {showSitemap ? <Link href="/sitemap.xml" className={styles.link}>Sitemap</Link> : null}
             <a href={storeUrl} target="_blank" rel="noopener noreferrer" className={styles.cta}>Store</a>
           </nav>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -38,6 +38,11 @@ export default function Header() {
           <Link className="u" href="/reviews">レビュー</Link>
           <Link className="u" href="/guides">ガイド</Link>
           <Link className="u" href="/topics">トピック</Link>
+          <Link className="u rss" href="/feed/posts.xml" title="ブログRSS" aria-label="ブログRSS">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M6.503 20.752c0 1.794-1.456 3.248-3.251 3.248-1.796 0-3.252-1.454-3.252-3.248 0-1.794 1.456-3.248 3.252-3.248 1.795.001 3.251 1.454 3.251 3.248zm-6.503-12.572v4.811c6.05.062 10.96 4.966 11.022 11.009h4.818c-.062-8.71-7.118-15.758-15.84-15.82zm0-3.368c10.58.046 19.152 8.594 19.183 19.188h4.817c-.03-13.231-10.755-23.954-24-24v4.812z"/>
+            </svg>
+          </Link>
           <Link className="u" href="/about">About</Link>
         </nav>
       </div>
@@ -66,6 +71,8 @@ export default function Header() {
         .util, .nav { display:flex; gap:10px; }
         .u, .i { padding:6px 10px; border-radius:10px; }
         .u:hover, .i:hover { background:#f3f4f6; }
+        .u.rss { padding:6px 8px; display:flex; align-items:center; color:#ff6600; }
+        .u.rss:hover { background:#fff3e6; }
         .i.active { background:#e0f2fe; color:#0284c7; font-weight:600; }
         .menubar { padding-top:4px; padding-bottom:10px; }
         .search input{ padding:6px 10px; border:1px solid #e5e7eb; border-radius:8px; min-width:160px; }


### PR DESCRIPTION
- Add OpenSearch descriptor at /opensearch.xml with search integration
- Create comprehensive RSS feeds: /feed/posts.xml, /feed/news.xml, /feed/tags/[slug].xml
- Support 15-20 items per feed with absolute URLs and lastBuildDate
- Add OpenSearch link to head and RSS feed links to header/footer icons
- Update robots.txt and sitemap.xml to expose all feed endpoints
- Integrate with existing news API for real-time news RSS generation
- Tag-specific RSS feeds with static generation for all available tags
- RSS icons in header navigation and comprehensive footer feed section
- Full SEO integration with proper caching and content-type headers