### PR TITLE
feat(og): implement dynamic OG/Twitter cards v2

### DIFF
--- a/app/brokers/[slug]/page.tsx
+++ b/app/brokers/[slug]/page.tsx
@@ -35,6 +35,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     };
   }
 
+  const ogImageUrl = `/api/og?type=broker&title=${encodeURIComponent(broker.name)}&subtitle=${encodeURIComponent(`${broker.country}のFXブローカー`)}&score=${broker.ratingValue}`
+
   return {
     title: `${broker.name} - FXブローカー詳細レビュー | 評価・スプレッド・安全性`,
     description: `${broker.name}の詳細レビュー。スプレッド、手数料、安全性、取引プラットフォームなど、実際の評価とユーザーレビューをご紹介。`,
@@ -43,6 +45,20 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
       description: `${broker.name}の詳細レビュー。スプレッド、手数料、安全性、取引プラットフォームなど、実際の評価とユーザーレビューをご紹介。`,
       type: 'article',
       url: `https://marlowgate.com${broker.url}`,
+      images: [
+        {
+          url: ogImageUrl,
+          width: 1200,
+          height: 630,
+          alt: `${broker.name} - FXブローカー詳細レビュー`,
+        },
+      ],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: `${broker.name} - FXブローカー詳細レビュー`,
+      description: `${broker.name}の詳細レビュー。評価: ${broker.ratingValue}/5.0`,
+      images: [ogImageUrl],
     },
     alternates: {
       canonical: `https://marlowgate.com${broker.url}`,

--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -17,6 +17,20 @@ export const metadata: Metadata = {
     description: '最新の金融市場ニュースや投資情報をリアルタイムでお届け。',
     type: 'website',
     url: 'https://marlowgate.com/news',
+    images: [
+      {
+        url: '/api/og?type=news&title=最新マーケットニュース&subtitle=FX・投資・暗号資産の最新情報をリアルタイムでお届け&source=Marlow Gate',
+        width: 1200,
+        height: 630,
+        alt: '最新マーケットニュース | Marlow Gate',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: '最新マーケットニュース | FX・投資情報',
+    description: '最新の金融市場ニュースや投資情報をリアルタイムでお届け。',
+    images: ['/api/og?type=news&title=最新マーケットニュース&subtitle=FX・投資・暗号資産の最新情報をリアルタイムでお届け&source=Marlow Gate'],
   },
   alternates: {
     canonical: 'https://marlowgate.com/news',


### PR DESCRIPTION
- Replace existing OG API with comprehensive satori/resvg-based card generation
- Support dynamic news and broker profile cards with metadata adaptation
- Add 2-line title truncation and contextual subtitles (source/time or score)
- Implement type-specific badges (ニュース/ブローカー) with color coding
- Fixed 1200x630 dimensions for consistent social media compatibility
- Update /news page metadata to use dynamic OG cards with source attribution
- Update /brokers/[slug] pages with rating score display and Twitter integration
- Maintain CLS 0 with static image dimensions and proper fallback handling
- Clean modern design with gradient branding and proper typography scaling